### PR TITLE
ci: add TypeScript build baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Lint, typecheck, and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint JavaScript configuration
+        run: npm run lint
+
+      - name: Typecheck source
+        run: npm run typecheck
+
+      - name: Build production site
+        run: npm run build
+
+      - name: Verify production artifact
+        run: test -s dist/index.html

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
What changed
- add a pinned least-privilege Node 22 CI workflow
- add npm run typecheck as the canonical tsc --noEmit command
- verify install, JavaScript configuration lint, TypeScript application typecheck, production build, and the generated index artifact

Workflow properties
- contents: read only
- persist-credentials: false
- checkout and setup-node pinned to immutable v7 SHAs
- npm cache
- concurrency cancellation
- 10-minute timeout

Verification
- npm ci
- npm run lint
- npm run typecheck
- npm run build
- test -s dist/index.html
- actionlint
- git diff --check
- independent review passed

Evidence boundary
- the existing ESLint config matches JS/JSX configuration files, not TS/TSX application source; the workflow labels that gate accurately
- TypeScript application coverage comes from tsc --noEmit
- the repository has no tests, and this PR does not imply or invent them
- package-lock.json is unchanged and npm ci confirms no lock update is needed for the scripts-only manifest edit
- the duplicate pre-existing vite.config.js and vite.config.ts files remain a separate cleanup