### PR TITLE
Deploy verified calendar demo to Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,59 @@
+name: Deploy Pages
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy green master commit
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Check out verified commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build GitHub Pages site
+        run: npm run build -- --mode github-pages
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        with:
+          path: dist
+
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A React-based visualization tool for managing and displaying timeshare periods of a vacation property. The application provides an interactive calendar view that helps track and visualize usage periods for different shares throughout the year.
 
+**[Open the live calendar](https://okturan.github.io/calendar-grid-react/)**
+
 ![Horizontal timeshare calendar with share2 selected and the other allocation periods dimmed](docs/calendar-grid-product-proof.png)
 
 *Actual production build with the horizontal layout enabled and `share2` selected. The three orange allocation periods remain prominent while the other shares are dimmed.*
@@ -58,3 +60,5 @@ npm run lint
 npm run typecheck
 npm run build
 ```
+
+Every successful `master` CI run deploys that exact commit to GitHub Pages. The deployment rebuilds with the repository-specific asset base and publishes only the generated `dist/` directory.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
+  base: mode === 'github-pages' ? '/calendar-grid-react/' : '/',
   plugins: [react()],
-})
+}))


### PR DESCRIPTION
## What changed

- deploy the exact green `master` commit to GitHub Pages after CI completes
- build with the repository-specific `/calendar-grid-react/` asset base
- document the live calendar URL and deployment boundary in the README

## Why

The repository already has current product proof and behavior/type/build CI, but recruiters cannot interact with the calendar from the repository page. This adds a static, secret-free deployment without changing the calendar behavior.

## Safety and scope

- deployment runs only after a successful `CI` push run on `master`
- checkout is pinned to that workflow run's exact commit
- workflow permissions are limited to contents read, Pages write, and OIDC
- only generated `dist/` output is published

## Verification

- `npm ci` (0 vulnerabilities)
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build -- --mode github-pages`
- verified repository-prefixed asset URLs in `dist/index.html`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
