### PR TITLE
Move Pages actions to Node 24

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -47,13 +47,13 @@ jobs:
         run: npm run build -- --mode github-pages
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: dist
 
       - name: Deploy GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5


### PR DESCRIPTION
## What changed

Upgrade the three pinned GitHub Pages actions to their current Node 24 majors:

- `actions/configure-pages` v6
- `actions/upload-pages-artifact` v5
- `actions/deploy-pages` v5

## Why

The first successful deployment exposed a GitHub Actions annotation because the previous Pages majors still targeted Node 20. These replacements use Node 24 and remove that warning while preserving the same exact-green-commit deployment flow.

## Verification

- confirmed each immutable tag SHA through the GitHub API
- confirmed `configure-pages` and `deploy-pages` declare `node24`
- confirmed `upload-pages-artifact` v5 uses `actions/upload-artifact` v7
- `actionlint .github/workflows/*.yml`
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build -- --mode github-pages`
- `git diff --check`
